### PR TITLE
Add specs for CompatibleTargetFinder service

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/factories/targets.rb
+++ b/spec/factories/targets.rb
@@ -33,5 +33,20 @@ FactoryBot.define do
     latitude { Faker::Address.latitude.round(10) }
     longitude { Faker::Address.longitude.round(10) }
     topic
+
+    trait :with_south_location do
+      latitude { rand(10.0..20.0) }
+      longitude { rand(-20.0..-10.0) }
+    end
+
+    trait :with_north_location do
+      latitude { rand(10.0..20.0) }
+      longitude { rand(10.0..20.0) }
+    end
+
+    trait :with_center_location do
+      latitude { 0.0 }
+      longitude { 0.0 }
+    end
   end
 end

--- a/spec/services/target_service/compatible_target_finder_spec.rb
+++ b/spec/services/target_service/compatible_target_finder_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Services::TargetService::CompatibleTargetFinder', type: :service do
+  subject { TargetService::CompatibleTargetFinder.new(target) }
+
+  let(:topic) { create(:topic) }
+  let!(:south_targets) { create_list(:target, 3, :with_south_location, topic: topic, radius: 1.0) }
+  let!(:north_targets) { create_list(:target, 3, :with_north_location, topic: topic, radius: 1.0) }
+
+  context 'when target matches the criteria - north targets' do
+    let!(:target) { create(:target, :with_north_location, topic: topic, radius: 2000.0) }
+
+    it 'sends notifications to the matched users' do
+      expect { subject.call }.to change(Notification, :count).by(3)
+    end
+
+    it 'sends emails to the matched users' do
+      expect { subject.call }.to have_enqueued_job(Noticed::DeliveryMethods::Email).exactly(3)
+    end
+  end
+
+  context 'when target matches the criteria - all targets' do
+    let!(:target) { create(:target, :with_center_location, topic: topic, radius: 10_000.0) }
+
+    it 'sends notifications to the matched users' do
+      expect { subject.call }.to change(Notification, :count).by(6)
+    end
+
+    it 'sends emails to the matched users' do
+      expect { subject.call }.to have_enqueued_job(Noticed::DeliveryMethods::Email).exactly(6)
+    end
+  end
+
+  context 'when target does not match the criteria' do
+    let!(:target) { create(:target, :with_center_location, topic: topic, radius: 0.0) }
+
+    it 'sends notifications to the matched users' do
+      expect { subject.call }.to change(Notification, :count).by(0)
+    end
+
+    it 'sends emails to the matched users' do
+      expect { subject.call }.to have_enqueued_job(Noticed::DeliveryMethods::Email).exactly(0)
+    end
+  end
+end


### PR DESCRIPTION
## Add specs for CompatibleTargetFinder service

* [Trello Card #8-5 Notify compatible targets ](https://trello.com/c/zfNc26k0/8-5-as-a-user-i-should-receive-notifications-when-a-compatible-target-has-been-created-so-we-can-start-getting-connected)
